### PR TITLE
Configuration Framework Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,49 @@
 # scala-utils
 
+## Description
+
 This project contains some basic utilities that can help setting up a Scala project.
 
 The main utilities available:
 - [Configuration framework](docs/configuration-framework.md)
 - Other utilities available in the `byteable` and `utils` packages
+
+
+## Prerequisites ##
+
+* Java 6 or higher
+* Scala 2.11,or 2.12
+
+
+## Getting Scala Utils ##
+
+Scala Utils is published to Sonatype OSS and Maven Central:
+
+- Group id / organization: `org.tupol`
+- Artifact id / name: `scala-utils`
+- Latest version is `0.2.0-SNAPSHOT`
+
+Usage with SBT, adding a dependency to the latest version of Scala Logging to your sbt build definition file:
+
+```scala
+libraryDependencies += "org.tupol" %% "scala-utils" % "0.2.0-SNAPSHOT"
+```
+
+
+## Usage
+
+Some usage examples can be found under [`src/test/scala/examples`](src/test/scala/examples).
+
+
+## What's new?
+
+### 0.2.0-SNAPSHOT
+ - `Configurator`s can also be used as `Extractor`s
+ - Added support for complex `Map` and `Seq` configuration types
+ - Added extractor for `Either` objects
+ - Added extractors for time related properties: `Duration`, `Timestamp`, `Date`, `LocalDateTime` and `LocalDate`
+
+
+## License ##
+
+This code is open source software licensed under the [MIT License](LICENSE).

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ name := "scala-utils"
 
 organization := "org.tupol"
 
+scalaVersion := "2.11.12"
+
 crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 // ------------------------------

--- a/docs/configuration-framework.md
+++ b/docs/configuration-framework.md
@@ -10,14 +10,17 @@ This section is describing the current configuration framework and most importan
 
 The configuration framework is based on *ScalaZ* `validation` infrastructure.
 
-The main reason for using the *ScalaZ* `ValidationNel` is to be able to collect all error messages found during the configuration of the target object, and showing them to the user in one go, rather than one by one, as each problem is fixed, application is ran again and the next problem is revealed.
+The main reason for using the *ScalaZ* `ValidationNel` is to be able to collect all error messages found during the
+configuration of the target object, and showing them to the user in one go, rather than one by one, as each problem is
+fixed, application is ran again and the next problem is revealed.
 
 The key concepts are:
 - `org.tupol.utils.Configurator`
 - `scalaz.ValidationNel`; for more details look [here](https://github.com/scalaz/scalaz/blob/series/7.2.x/core/src/main/scala/scalaz/Validation.scala)
 - `com.typesafe.config.Config`; for more details look [here](https://github.com/typesafehub/config)
 
-The `Configurator` is used as a factory for case classes starting from a Typesafe `Config` instance, as shown in the `Configurator` trait itself:
+The `Configurator` is used as a factory for case classes starting from a Typesafe `Config` instance, as shown in the
+`Configurator` trait itself:
 
 ```scala
   import com.typesafe.config.Config
@@ -44,7 +47,8 @@ The full example is available in [`examples.MySimpleExample`](src/test/scala/exa
 
 #### 1. Create a case class to configure or select an existing one
 
-The normal pattern we used so far is to create a configuration case class that will only hold the configuration of the class we actually want to configure.
+The normal pattern we used so far is to create a configuration case class that will only hold the configuration of the
+class we actually want to configure.
 This is not the only way of doing it, and we can configure any case class directly (see the `NaiveProbifier`).
 
 Let's say that we have an example class that we need to configure, like bellow:
@@ -103,14 +107,20 @@ object MySimpleExample extends Configurator[MySimpleExample] {
     - the `|@|` operator is used to compose `ValidationNel[Throwable, T]`s and create an `ApplicativeBuilder` 
     - on the `ApplicativeBuilder` created  we can call `apply` and pass in a function that creates our object, `MySimpleExample`
     - for a case class or for smart constructor in companion objects, such an function is `apply`
-    - the order of the `config.extract[T]("configuration_path")` is very important and it needs to match the type signature of the case class we are trying to construct;
-      In our example we can not change the order of `config.extract[String]("path")` and `config.extract[Boolean]("overwrite")` because composing them will create a tuple of Boolean and String and there is no such constructor available in `MySimpleExample`
-    - in case our target class has multiple constructors, we need to specify the constructor better; for example we can use something like `MyComplexExample.apply(_, _, _)`
+    - the order of the `config.extract[T]("configuration_path")` is very important and it needs to match the type
+      signature of the case class we are trying to construct;
+      In our example we can not change the order of `config.extract[String]("path")` and `config.extract[Boolean]("overwrite")`
+      because composing them will create a tuple of Boolean and String and there is no such constructor available
+      in `MySimpleExample`
+    - in case our target class has multiple constructors, we need to specify the constructor better; for example we
+      can use something like `MyComplexExample.apply(_, _, _)`
     - the final result of the `validationNel` function is a `ValidationNel[Throwable, T]`
 
 6. When actually building a configured instance, the `apply` function will be used, that yields a `Try[T]`.
     - the returned try may contain either the successfully configured instance or a failure containing a `ConfigurationException` 
-    - the `ConfigurationException` wraps all the `Throwables` accumulated by the `ValidationNel` and has a human friendly message that lists all the problems.
+    - the `ConfigurationException` wraps all the `Throwables` accumulated by the `ValidationNel` and has a human
+      friendly message that lists all the problems.
+
 
 
 ### Composite Configuration Example
@@ -166,18 +176,60 @@ object MyComplexExample extends Configurator[MyComplexExample] {
 }
 ```
 
+A defined `Configurator` can also be used as an `Extractor` itself, so with a simple `implicit` the example above can be
+written more elegantly like the following:
+
+
+```scala
+import org.tupol.scala.config.Configurator
+
+implicit val mySimpleExampleExtractor = MySimpleExample
+
+object MyComplexExample extends Configurator[MyComplexExample] {
+
+  import com.typesafe.config.Config
+  import scalaz.ValidationNel
+
+  override def validationNel(config: Config): ValidationNel[Throwable, MyComplexExample] = {
+
+    import org.tupol.scala.config._
+    import scalaz.syntax.applicative._
+    import com.typesafe.config.ConfigException.BadValue
+
+    val separatorChar = config.extract[String]("separatorChar").
+      ensure(new BadValue("separatorChar", "should be a single character.").toNel)(t => t.length == 1)
+
+    val separatorSize = config.extract[Int]("separatorSize").
+      ensure(new IllegalArgumentException("The separatorSize should be between 1 and 80.").toNel)(s => s > 0 && s <= 80)
+
+    val mySimpleExample = config.extract[MySimpleExample]
+
+    mySimpleExample |@| separatorChar |@| separatorSize apply MyComplexExample.apply
+  }
+}
+```
+
+Notice in the example above the implicit definition of the `MySimpleExample` extractor as
+`implicit val mySimpleExampleExtractor = MySimpleExample`.
+Also notice the actual extraction of `MySimpleExample` inside the `MyComplexExample.validationNel` function,
+as `config.extract[MySimpleExample]`.
+This pattern can simplify a lot the way complex configuration objects are created.
+
 
 ***Notes***
 
 1. Notice the way the `separatorChar` and `separatorSize` are defined outside the `ApplicativeBuilder` composition line.
 
-2. Notice that both `separatorChar` and `separatorSize` have extra validation rules implemented through the `ensure` function.
+2. Notice that both `separatorChar` and `separatorSize` have extra validation rules implemented through the `ensure`
+   function.
     - the `ensure` function 
         - takes as a first argument a function that creates a `Throwable` and 
         - takes as a second argument a predicate that is applied to the value contained in the `ValidationNel`
-        - if testing the value against the predicate fails, then the `Throwable` defined as a first parameter is added to the `NonEmptyList[Throwable]` of the `ValidationNel`
+        - if testing the value against the predicate fails, then the `Throwable` defined as a first parameter is added
+          to the `NonEmptyList[Throwable]` of the `ValidationNel`
         - for more details don't hesitate to check the [scalaz documentation](https://github.com/scalaz/scalaz/blob/series/7.2.x/core/src/main/scala/scalaz/Validation.scala)
-    - the `Throwable`s are implicitly converted to `NonEmptyList[Throwable]` by the `org.tupol.utils.config._` package defined implicits;
+    - the `Throwable`s are implicitly converted to `NonEmptyList[Throwable]` by the `org.tupol.utils.config._` package
+      defined implicits;
       This way the type signature `ValidationNel[Throwable, T]` is preserved.
       
 3. For the final line to work, `MySimpleExample.validationNel(config)` needs to be defined.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
 

--- a/src/test/scala/examples/MyComplexExample.scala
+++ b/src/test/scala/examples/MyComplexExample.scala
@@ -60,13 +60,15 @@ object MyComplexExample extends Configurator[MyComplexExample] {
 
     import scalaz.syntax.applicative._
 
+    implicit val mySimpleExampleConfigExtractor = MySimpleExample
+
     val separatorChar = config.extract[String]("separatorChar").
       ensure(new BadValue("separatorChar", "should be a single character.").toNel)(t => t.length == 1)
 
     val separatorSize = config.extract[Int]("separatorSize").
       ensure(new IllegalArgumentException("The separatorSize should be between 1 and 80.").toNel)(s => s > 0 && s <= 80)
 
-    MySimpleExample.validationNel(config) |@| separatorChar |@| separatorSize apply MyComplexExample.apply
+    config.extract[MySimpleExample] |@| separatorChar |@| separatorSize apply MyComplexExample.apply
   }
 }
 
@@ -82,14 +84,12 @@ object MyComplexExampleDemo extends App {
       |myExample.overwrite=true
       |myExample.separatorChar="*"
       |myExample.separatorSize=15
-    """.stripMargin
-  )
+    """.stripMargin)
 
   println(
     s"""===============
         | Positive Test
-        |===============""".stripMargin
-  )
+        |===============""".stripMargin)
   // This is the place where the "magic happens" and everything goes well
   // Notice that we extract the exact configuration that we need out of the root configuration object
   // by calling `goodConfig.getConfig("myExample")`
@@ -100,8 +100,7 @@ object MyComplexExampleDemo extends App {
     s"""|
         |===============
         | Negative Test
-        |===============""".stripMargin
-  )
+        |===============""".stripMargin)
   // This is where we see what happens when there are some problems
   val wrongConfig = ConfigFactory.parseString(
     """
@@ -110,8 +109,7 @@ object MyComplexExampleDemo extends App {
       |  separatorChar="--"
       |  separatorSize=81
       |}
-    """.stripMargin
-  )
+    """.stripMargin)
   print(MyComplexExample(wrongConfig.getConfig("myExample")).recover { case (t: Throwable) => t.getMessage }.get)
 }
 

--- a/src/test/scala/examples/MySimpleExample.scala
+++ b/src/test/scala/examples/MySimpleExample.scala
@@ -68,14 +68,12 @@ object MySimpleExampleDemo extends App {
     """
       |myExample.path="some_path"
       |myExample.overwrite=true
-    """.stripMargin
-  )
+    """.stripMargin)
 
   println(
     s"""===============
         | Positive Test
-        |===============""".stripMargin
-  )
+        |===============""".stripMargin)
   // This is the place where the "magic happens" and everything goes well
   // Notice that we extract the exact configuration that we need out of the root configuration object
   // by calling `goodConfig.getConfig("myExample")`
@@ -86,14 +84,12 @@ object MySimpleExampleDemo extends App {
     s"""|
         |===============
         | Negative Test
-        |===============""".stripMargin
-  )
+        |===============""".stripMargin)
   // This is where we see what happens when there are some problems
   val wrongConfig = ConfigFactory.parseString(
     """
       |myExample: {}
-    """.stripMargin
-  )
+    """.stripMargin)
   print(MySimpleExample(wrongConfig.getConfig("myExample")).recover { case (t: Throwable) => t.getMessage }.get)
 }
 

--- a/src/test/scala/org/tupol/utils/TryOpsSpec.scala
+++ b/src/test/scala/org/tupol/utils/TryOpsSpec.scala
@@ -36,8 +36,7 @@ class TryOpsSpec extends FunSuite with Matchers {
     val loggerFailure = ArrayBuffer[String]()
     Success(1).log(
       message => loggerSuccess.append(message),
-      throwable => loggerFailure.append(throwable.getMessage)
-    )
+      throwable => loggerFailure.append(throwable.getMessage))
     loggerSuccess should contain theSameElementsAs Seq(1)
     loggerFailure.isEmpty shouldBe true
   }
@@ -47,8 +46,7 @@ class TryOpsSpec extends FunSuite with Matchers {
     val loggerFailure = ArrayBuffer[String]()
     Failure[Int](new Exception("1")).log(
       message => loggerSuccess.append(message),
-      throwable => loggerFailure.append(throwable.getMessage)
-    )
+      throwable => loggerFailure.append(throwable.getMessage))
     loggerSuccess.isEmpty shouldBe true
     loggerFailure should contain theSameElementsAs Seq("1")
   }

--- a/src/test/scala/org/tupol/utils/config/CompositeExtractorSpec.scala
+++ b/src/test/scala/org/tupol/utils/config/CompositeExtractorSpec.scala
@@ -1,0 +1,55 @@
+package org.tupol.utils.config
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ FunSuite, Matchers }
+import scalaz.syntax.applicative._
+import scalaz.{ ValidationNel, Failure => ZFailure }
+
+class CompositeExtractorSpec extends FunSuite with Matchers {
+
+  case class CustomConf(prop1: Int, prop2: Seq[Long])
+  object CustomConf extends Configurator[CustomConf] {
+    override def validationNel(config: Config): ValidationNel[Throwable, CustomConf] = {
+      config.extract[Int]("prop1") |@| config.extract[Seq[Long]]("prop2") apply CustomConf.apply
+    }
+  }
+
+  test("Extract CustomConf from path should be successful") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |cc: {prop1 : 0, prop2: [21, 22]}
+                                           """.stripMargin)
+    val actual = config.extract[CustomConf]("cc").get
+    val expected = CustomConf(0, Seq(21, 22))
+    actual shouldBe expected
+  }
+
+  test("Extract CustomConf from path should fail for bad values") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |cc: {prop1 : 0, prop2: [21, a]}
+                                           """.stripMargin)
+    val actual = config.extract[CustomConf]("cc")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extract CustomConf with no path should be successful") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |{prop1 : 0, prop2: [1, 2]}
+                                           """.stripMargin)
+    val actual = config.extract[CustomConf].get
+    val expected = CustomConf(0, Seq(1, 2))
+    actual shouldBe expected
+  }
+
+  test("Extract CustomConf with no path should fail for bad values") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |{prop1 : 0, prop2: [21, a]}
+                                           """.stripMargin)
+    val actual = config.extract[CustomConf]
+    actual shouldBe a[ZFailure[_]]
+  }
+
+}

--- a/src/test/scala/org/tupol/utils/config/EitherExtractorSpec.scala
+++ b/src/test/scala/org/tupol/utils/config/EitherExtractorSpec.scala
@@ -1,0 +1,46 @@
+package org.tupol.utils.config
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ FunSuite, Matchers }
+import scalaz.syntax.applicative._
+import scalaz.{ ValidationNel, Failure => ZFailure }
+
+class EitherExtractorSpec extends FunSuite with Matchers {
+
+  case class CustomConf(prop1: Int, prop2: Seq[Long])
+  object CustomConf extends Configurator[CustomConf] {
+    override def validationNel(config: Config): ValidationNel[Throwable, CustomConf] = {
+      config.extract[Int]("prop1") |@| config.extract[Seq[Long]]("prop2") apply CustomConf.apply
+    }
+  }
+
+  test("Extract Either an Int or a CustomConf returns an Int") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |either: 111
+                                           """.stripMargin)
+    val actual = config.extract[Either[Int, CustomConf]]("either").get
+    val expected = 111
+    actual shouldBe Left(expected)
+  }
+
+  test("Extract Either an Int or a CustomConf returns a CustomConf") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |either: {prop1 : 0, prop2: [1, 2]}
+                                           """.stripMargin)
+    val actual = config.extract[Either[Int, CustomConf]]("either").get
+    val expected = CustomConf(0, Seq(1, 2))
+    actual shouldBe Right(expected)
+  }
+
+  test("Extract Either an Int or a CustomConf should fail if no match") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |either: "-incorrect_value-"
+                                           """.stripMargin)
+    val actual = config.extract[Either[Int, CustomConf]]
+    actual shouldBe a[ZFailure[_]]
+  }
+
+}

--- a/src/test/scala/org/tupol/utils/config/OptionExtractorSpec.scala
+++ b/src/test/scala/org/tupol/utils/config/OptionExtractorSpec.scala
@@ -1,0 +1,62 @@
+package org.tupol.utils.config
+
+import java.sql.Timestamp
+
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
+import org.scalatest
+import org.scalatest.{ FunSuite, Matchers, prop }
+import scalaz.ValidationNel
+import scalaz.syntax.applicative._
+
+import scala.collection.JavaConversions._
+import scala.util.{ Failure, Success, Try }
+import scalaz.{ Failure => ZFailure }
+
+class OptionExtractorSpec extends FunSuite with Matchers {
+
+  case class ComplexExample(char: Character, str: String, bool: Boolean, dbl: Double, in: Int, lng: Long,
+    optChar: Option[Character], optStr: Option[String], optBool: Option[Boolean],
+    optDouble: Option[Double], optInt: Option[Int], optLong: Option[Long])
+
+  test("Missing optional values should not result in error") {
+    val complexInstance = ComplexExample('*', "string", false, 0.9d, 23, 12L, None, None, None, None, None, None)
+    val config = ConfigFactory.parseMap(Map("char" -> "*", "str" -> "string", "bool" -> "false", "dbl" -> "0.9", "in" -> "23", "lng" -> "12"))
+    val validationResult: Try[ComplexExample] =
+      config.extract[Character]("char") |@| config.extract[String]("str") |@|
+        config.extract[Boolean]("bool") |@| config.extract[Double]("dbl") |@|
+        config.extract[Int]("in") |@| config.extract[Long]("lng") |@|
+        config.extract[Option[Character]]("optchar") |@| config.extract[Option[String]]("optstr") |@|
+        config.extract[Option[Boolean]]("optbool") |@| config.extract[Option[Double]]("optdbl") |@|
+        config.extract[Option[Int]]("optin") |@| config.extract[Option[Long]]("optlng") apply ComplexExample.apply
+
+    validationResult shouldEqual Success(complexInstance)
+  }
+
+  test("Optional values should be parsed when present") {
+    val complexInstance = ComplexExample('*', "string", false, 0.9d, 23, 12L, Some('*'), Some("string"), Some(false), Some(0.9d), Some(23), Some(12l))
+    val config = ConfigFactory.parseMap(Map("char" -> "*", "str" -> "string", "bool" -> "false", "dbl" -> "0.9", "in" -> "23", "lng" -> "12",
+      "optchar" -> "*", "optstr" -> "string", "optbool" -> "false", "optdbl" -> "0.9", "optin" -> "23", "optlng" -> "12"))
+    val validationResult: Try[ComplexExample] = config.extract[Character]("char") |@| config.extract[String]("str") |@| config.extract[Boolean]("bool") |@| config.extract[Double]("dbl") |@|
+      config.extract[Int]("in") |@| config.extract[Long]("lng") |@| config.extract[Option[Character]]("optchar") |@| config.extract[Option[String]]("optstr") |@|
+      config.extract[Option[Boolean]]("optbool") |@| config.extract[Option[Double]]("optdbl") |@| config.extract[Option[Int]]("optin") |@| config.extract[Option[Long]]("optlng") apply ComplexExample.apply
+
+    validationResult shouldEqual Success(complexInstance)
+  }
+
+  case class SimpleExample(char: Character, bool: Boolean, in: Int)
+
+  test("Missing non optional values should result in a Failure") {
+    val config = ConfigFactory.parseMap(Map("char" -> "*", "in" -> "23"))
+    val validationResult: Try[SimpleExample] = config.extract[Character]("char") |@| config.extract[Boolean]("bool") |@| config.extract[Int]("in") apply SimpleExample.apply
+
+    validationResult.failed.map(_.getMessage).get should include("No configuration setting found for key 'bool'")
+  }
+
+  test("Non optional values of the wrong type should result in a Failure") {
+    val config = ConfigFactory.parseMap(Map("char" -> "*", "bool" -> "nee", "in" -> "234,34"))
+    val validationResult: Try[SimpleExample] = config.extract[Character]("char") |@| config.extract[Boolean]("bool") |@| config.extract[Int]("in") apply SimpleExample.apply
+    validationResult.failed.map(_.getMessage).get should include("hardcoded value: bool has type STRING rather than BOOLEAN")
+    validationResult.failed.map(_.getMessage).get should include("hardcoded value: in has type STRING rather than NUMBER")
+  }
+
+}

--- a/src/test/scala/org/tupol/utils/config/PrimitiveExtractorSpec.scala
+++ b/src/test/scala/org/tupol/utils/config/PrimitiveExtractorSpec.scala
@@ -1,0 +1,184 @@
+package org.tupol.utils.config
+
+import java.sql.{ Date, Timestamp }
+import java.time.{ Duration, LocalDate, LocalDateTime }
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ FunSuite, Matchers }
+import scalaz.{ Failure => ZFailure }
+
+class PrimitiveExtractorSpec extends FunSuite with Matchers {
+
+  case class ComplexExample(char: Character, str: String, bool: Boolean, dbl: Double, in: Int, lng: Long,
+    optChar: Option[Character], optStr: Option[String], optBool: Option[Boolean],
+    optDouble: Option[Double], optInt: Option[Int], optLong: Option[Long])
+
+  test("Extracting a String") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "10h"
+                                           """.stripMargin)
+    val actual = config.extract[String]("property").get
+    actual shouldEqual "10h"
+  }
+
+  test("Extracting a true Boolean") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "true"
+                                           """.stripMargin)
+    val actual = config.extract[Boolean]("property").get
+    actual shouldEqual true
+  }
+
+  test("Extracting a false Boolean") {
+    val config = ConfigFactory.parseString("""
+                                             |property: false
+                                           """.stripMargin)
+    val actual = config.extract[Boolean]("property").get
+    actual shouldEqual false
+  }
+
+  test("Extracting an unknown Boolean fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: whaaat
+                                           """.stripMargin)
+    val actual = config.extract[Boolean]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting an Int") {
+    val config = ConfigFactory.parseString("""
+                                             |property: 123123123
+                                           """.stripMargin)
+    val actual = config.extract[Int]("property").get
+    actual shouldEqual 123123123
+  }
+
+  test("Extracting an Int fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: whaaat
+                                           """.stripMargin)
+    val actual = config.extract[Int]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a Long") {
+    val config = ConfigFactory.parseString("""
+                                             |property: 123123123
+                                           """.stripMargin)
+    val actual = config.extract[Long]("property").get
+    actual shouldEqual 123123123L
+  }
+
+  test("Extracting a Long fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: whaaat
+                                           """.stripMargin)
+    val actual = config.extract[Long]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a Double") {
+    val config = ConfigFactory.parseString("""
+                                             |property: 123123123
+                                           """.stripMargin)
+    val actual = config.extract[Double]("property").get
+    actual shouldEqual 123123123L
+  }
+
+  test("Extracting a Double fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: whaaat
+                                           """.stripMargin)
+    val actual = config.extract[Double]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a Duration") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "10h"
+                                           """.stripMargin)
+    val actual = config.extract[Duration]("property").get
+    actual shouldEqual Duration.ofHours(10)
+  }
+
+  test("Extracting a Duration fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "x"
+                                           """.stripMargin)
+    val actual = config.extract[Date]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a Date") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-23"
+                                           """.stripMargin)
+    val actual = config.extract[Date]("property").get
+    actual shouldEqual Date.valueOf("2018-12-23")
+  }
+
+  test("Extracting a Date fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-44"
+                                           """.stripMargin)
+    val actual = config.extract[Date]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a Timestamp with millis") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-23 10:23:59.001"
+                                           """.stripMargin)
+    val actual = config.extract[Timestamp]("property").get
+    actual shouldEqual Timestamp.valueOf("2018-12-23 10:23:59.001")
+  }
+
+  test("Extracting a Timestamp no millis") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-23 10:23:59"
+                                           """.stripMargin)
+    val actual = config.extract[Timestamp]("property").get
+    actual shouldEqual Timestamp.valueOf("2018-12-23 10:23:59")
+  }
+
+  test("Extracting a Timestamp fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "abc"
+                                           """.stripMargin)
+    val actual = config.extract[Timestamp]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a LocalDate") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-23"
+                                           """.stripMargin)
+    val actual = config.extract[LocalDate]("property").get
+    actual shouldEqual LocalDate.of(2018, 12, 23)
+  }
+
+  test("Extracting a LocalDate fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-44"
+                                           """.stripMargin)
+    val actual = config.extract[LocalDate]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+  test("Extracting a LocalDateTime") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-23T10:23:59"
+                                           """.stripMargin)
+    val actual = config.extract[LocalDateTime]("property").get
+    actual shouldEqual LocalDateTime.of(2018, 12, 23, 10, 23, 59)
+  }
+
+  test("Extracting a LocalDateTime fails") {
+    val config = ConfigFactory.parseString("""
+                                             |property: "2018-12-44 10:23:59"
+                                           """.stripMargin)
+    val actual = config.extract[LocalDateTime]("property")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+}

--- a/src/test/scala/org/tupol/utils/config/SeqExtractorSpec.scala
+++ b/src/test/scala/org/tupol/utils/config/SeqExtractorSpec.scala
@@ -1,0 +1,42 @@
+package org.tupol.utils.config
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ FunSuite, Matchers }
+import scalaz.syntax.applicative._
+import scalaz.{ ValidationNel, Failure => ZFailure }
+
+class SeqExtractorSpec extends FunSuite with Matchers {
+
+  case class CustomConf(prop1: Int, prop2: Seq[Long])
+  object CustomConf extends Configurator[CustomConf] {
+    override def validationNel(config: Config): ValidationNel[Throwable, CustomConf] = {
+      config.extract[Int]("prop1") |@| config.extract[Seq[Long]]("prop2") apply CustomConf.apply
+    }
+  }
+
+  test("Extract a Seq[CustomConf] should be successful") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |customs :[
+                                             |   {prop1 : 1, prop2: [11, 12]},
+                                             |   {prop1 : 2, prop2: [21, 22]}
+                                             |]
+                                           """.stripMargin)
+    val actual = config.extract[Seq[CustomConf]]("customs").get
+    val expected = Seq(CustomConf(1, Seq(11, 12)), CustomConf(2, Seq(21, 22)))
+    actual should contain theSameElementsAs (expected)
+  }
+
+  test("Extract a Seq[CustomConf] should fail for bad values") {
+    implicit val customConfExtractor = CustomConf
+    val config = ConfigFactory.parseString("""
+                                             |customs :[
+                                             |   {prop1 : 1, prop2: [11, 12]},
+                                             |   {prop1 : c, prop2: [21, 22]}
+                                             |]
+                                           """.stripMargin)
+    val actual = config.extract[Seq[CustomConf]]("customs")
+    actual shouldBe a[ZFailure[_]]
+  }
+
+}

--- a/src/test/scala/org/tupol/utils/config/StringToRangeProp.scala
+++ b/src/test/scala/org/tupol/utils/config/StringToRangeProp.scala
@@ -2,31 +2,53 @@ package org.tupol.utils.config
 
 import com.typesafe.config.ConfigException.BadValue
 import org.scalacheck.Prop.forAll
-import org.scalacheck.Properties
+import org.scalacheck.{ Gen, Properties }
 import org.scalatest.Matchers
-import Extractor.rangeExtractor.parseStringToRange
+import org.tupol.utils.config.Extractor.rangeExtractor.parseStringToRange
 
 class StringToRangeProp extends Properties("Range") with Matchers {
 
-  property("commons#parseStringToRange - creates sequence for a single int value") = forAll { (i: Int) =>
-    val input = i.toString
+  val positiveInts = for (n <- Gen.choose(0, 100)) yield n
+  val negativeInts = for (n <- Gen.choose(-100, -1)) yield n
+
+  property("commons#parseStringToRange - creates sequence for a single int value") = forAll(positiveInts) { (i: Int) =>
+
+    val input = s"$i"
     val output = parseStringToRange(input, "somePath")
 
     output.head == i
+    output.last == i
+  }
+
+  property("commons#parseStringToRange - creates sequence for a fully defined range") = forAll(positiveInts) { (i: Int) =>
+    val input = s"${i}, ${i + 10}, 1"
+    val output = parseStringToRange(input, "somePath")
+    output.head == i
+    output.last == i + 10
+  }
+
+  property("commons#parseStringToRange - throws BadValue for start values greater than stop values") = forAll(positiveInts) { (i: Int) =>
+    val input = s"${i + 1}, $i, 1"
+    val ex = intercept[BadValue] {
+      parseStringToRange(input, "somePath")
+    }
+    ex.isInstanceOf[BadValue]
+  }
+
+  property("commons#parseStringToRange - throws BadValue for negative steps") = forAll(positiveInts, negativeInts) { (i: Int, s: Int) =>
+    val input = s"$i, ${i + 1}, $s"
+    val ex = intercept[BadValue] {
+      parseStringToRange(input, "somePath")
+    }
+    ex.isInstanceOf[BadValue]
   }
 
   property("commons#parseStringToRange - throws BadValue for any string") = forAll { (input: String) =>
+    val badInput = s"_ $input;@#*&"
     val ex = intercept[BadValue] {
       parseStringToRange(input, "somePath")
     }
     ex.isInstanceOf[BadValue]
   }
 
-  property("commons#parseStringToRange - throws BadValue for any string separated by commas") = forAll { (start: String, stop: String, step: String) =>
-    val input = start + "," + stop + "," + step
-    val ex = intercept[BadValue] {
-      parseStringToRange(input, "somePath")
-    }
-    ex.isInstanceOf[BadValue]
-  }
 }

--- a/src/test/scala/org/tupol/utils/config/StringToRangeSpec.scala
+++ b/src/test/scala/org/tupol/utils/config/StringToRangeSpec.scala
@@ -1,0 +1,53 @@
+package org.tupol.utils.config
+
+import com.typesafe.config.ConfigException.BadValue
+import org.scalatest.{ FunSuite, Matchers }
+import org.tupol.utils.config.Extractor.rangeExtractor.parseStringToRange
+
+class StringToRangeSpec extends FunSuite with Matchers {
+
+  test("commons#parseStringToRange - creates sequence for a single int value") {
+    val i = 1
+    val input = s"$i"
+    val output = parseStringToRange(input, "somePath")
+
+    output.head shouldBe i
+    output.last shouldBe i
+  }
+
+  test("commons#parseStringToRange - creates sequence") {
+    val i = 1
+    val input = s"${i}, ${i + 10}, 1"
+    val output = parseStringToRange(input, "somePath")
+
+    output.head shouldBe i
+    output.last shouldBe i + 10
+  }
+
+  test("commons#parseStringToRange - throws BadValue for start values greater than stop values") {
+    val i = 1
+    val input = s"${i + 1}, $i, 1"
+    val ex = intercept[BadValue] {
+      parseStringToRange(input, "somePath")
+    }
+    ex.isInstanceOf[BadValue]
+  }
+
+  test("commons#parseStringToRange - throws BadValue for negative steps") {
+    val i = 1
+    val input = s"$i, ${i + 1}, -1"
+    val ex = intercept[BadValue] {
+      parseStringToRange(input, "somePath")
+    }
+    ex.isInstanceOf[BadValue]
+  }
+
+  test("commons#parseStringToRange - throws BadValue for any malformed string") {
+    val input = "sdfsdf"
+    val ex = intercept[BadValue] {
+      parseStringToRange(input, "somePath")
+    }
+    ex.isInstanceOf[BadValue]
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
- `Configurator`s can also be used as `Extractor`s
- Added support for complex `Map` and `Seq` configuration types
- Added extractor for `Either` objects
- Added extractors for time related properties: `Duration`, `Timestamp`, `Date`, `LocalDateTime` and `LocalDate`
- Incremented the minor version